### PR TITLE
Fix react native import name

### DIFF
--- a/src/main/scala/sri/universal/components/Image.scala
+++ b/src/main/scala/sri/universal/components/Image.scala
@@ -106,7 +106,7 @@ object Image {
 
 }
 @js.native
-@JSImport("react-native", "ImageBackground")
+@JSImport("react-native", "Image")
 object ImageBackgroundComponent extends JSComponent[ImageProps] {
 
   def getSize(uri: String,


### PR DESCRIPTION
ImageBackground doesn't exist in react native, it should still be an Image which accepts children